### PR TITLE
Reconcile Optimizations from S4

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,17 +21,47 @@ python -m s4.train --dataset mnist-classification --model s4 --epochs 10 --bsz 1
 #### CIFAR-10 Classification
 
 ```bash
+## Adding a Cubic Decay Schedule for last 70% of training
+
+# Default arguments (100 epochs for CIFAR)
+python -m s4.train --dataset cifar-classification --model s4 --epochs 100 --bsz 128 --d_model 128 --ssm_n 64 --lr 1e-2 --lr_schedule
+
+# S4 replication from central repository
+python -m s4.train --dataset cifar-classification --model s4 --epochs 100 --bsz 64 --d_model 512 --ssm_n 64 --lr 1e-2 --lr_schedule
+
+## After Fixing S4-Custom Optimization & Dropout2D (all implemented inline now... can add flags if desired)
+
+# Default arguments (100 epochs for CIFAR)
+python -m s4.train --dataset cifar-classification --model s4 --epochs 100 --bsz 128 --d_model 128 --ssm_n 64 --lr 1e-2
+
+# S4 replication from central repository
+python -m s4.train --dataset cifar-classification --model s4 --epochs 100 --bsz 64 --d_model 512 --ssm_n 64 --lr 1e-2
+
+## Before Fixing S4-Custom Optimization...
+
 # Default arguments (100 epochs for CIFAR)
 python -m s4.train --dataset cifar-classification --model s4 --epochs 100 --bsz 128 --d_model 128 --ssm_n 64
 
-# S4 replication (close enough to params in original repo's example.py -- no LR schedule though!)
+# S4 replication from central repository
 python -m s4.train --dataset cifar-classification --model s4 --epochs 100 --bsz 64 --d_model 512 --ssm_n 64
 ```
 
-(Default Arguments): Gets "best" 65.51% accuracy @ 46s/epoch on a TitanRTX
+Adding a Schedule:
+- (LR 1e-2 w/ Replication Args -- "big" model): ?? @ ?? on a TitanRTX
+- (LR 1e-2 w/ Default Args -- not "bigger" model): ? @ 36s/epoch on a TitanRTX
 
-(S4 Arguments): Gets "best" 66.44% accuracy @ 3m11s on a TitanRTX
-    - Possible reasons for failure to meet replication: LR Schedule (Decay on Plateau), Custom LR per Parameter.
+After Fixing Dropout2D (w/ Optimization in Place):
+- (LR 1e-2 w/ Replication Args -- "big" model): ?? @ 3m17s on a TitanRTX
+- (LR 1e-2 w/ Default Args -- not "bigger" model): 69.20% @ 36s/epoch on a TitanRTX
+
+After Fixing Optimization, Before Fixing Dropout2D:
+- (LR 1e-2 w/ Default Args -- not "bigger" model): 67.14% @ 36s/epoch on a TitanRTX 
+
+Before Fixing S4 Optimization -- AdamW w/ LR 1e-3 for ALL Parameters:
+
+- (Default Arguments): Gets "best" 63.51% accuracy @ 46s/epoch on a TitanRTX
+- (S4 Arguments): Gets "best" 66.44% accuracy @ 3m11s on a TitanRTX
+    + Possible reasons for failure to meet replication: LR Schedule (Decay on Plateau), Custom LR per Parameter.
 
 ## Quickstart (Development)
 

--- a/README.md
+++ b/README.md
@@ -47,11 +47,11 @@ python -m s4.train --dataset cifar-classification --model s4 --epochs 100 --bsz 
 ```
 
 Adding a Schedule:
-- (LR 1e-2 w/ Replication Args -- "big" model): ^70% (still running, 39 epochs) @ 3m16s on a TitanRTX
+- (LR 1e-2 w/ Replication Args -- "big" model): 71.55% (still running, 39 epochs) @ 3m16s on a TitanRTX
 - (LR 1e-2 w/ Default Args -- not "bigger" model): 71.92% @ 36s/epoch on a TitanRTX
 
 After Fixing Dropout2D (w/ Optimization in Place):
-- (LR 1e-2 w/ Replication Args -- "big" model): ^70% (still running, 47 epochs) @ 3m17s on a TitanRTX
+- (LR 1e-2 w/ Replication Args -- "big" model): 70.68% (still running, 47 epochs) @ 3m17s on a TitanRTX
 - (LR 1e-2 w/ Default Args -- not "bigger" model): 68.20% @ 36s/epoch on a TitanRTX
 
 After Fixing Optimization, Before Fixing Dropout2D:

--- a/README.md
+++ b/README.md
@@ -47,12 +47,12 @@ python -m s4.train --dataset cifar-classification --model s4 --epochs 100 --bsz 
 ```
 
 Adding a Schedule:
-- (LR 1e-2 w/ Replication Args -- "big" model): ?? @ ?? on a TitanRTX
-- (LR 1e-2 w/ Default Args -- not "bigger" model): ? @ 36s/epoch on a TitanRTX
+- (LR 1e-2 w/ Replication Args -- "big" model): ^70% (still running, 39 epochs) @ 3m16s on a TitanRTX
+- (LR 1e-2 w/ Default Args -- not "bigger" model): 71.92% @ 36s/epoch on a TitanRTX
 
 After Fixing Dropout2D (w/ Optimization in Place):
-- (LR 1e-2 w/ Replication Args -- "big" model): ?? @ 3m17s on a TitanRTX
-- (LR 1e-2 w/ Default Args -- not "bigger" model): 69.20% @ 36s/epoch on a TitanRTX
+- (LR 1e-2 w/ Replication Args -- "big" model): ^70% (still running, 47 epochs) @ 3m17s on a TitanRTX
+- (LR 1e-2 w/ Default Args -- not "bigger" model): 68.20% @ 36s/epoch on a TitanRTX
 
 After Fixing Optimization, Before Fixing Dropout2D:
 - (LR 1e-2 w/ Default Args -- not "bigger" model): 67.14% @ 36s/epoch on a TitanRTX 

--- a/s4/train.py
+++ b/s4/train.py
@@ -370,7 +370,7 @@ def example_train(
 
         # Save a checkpoint each epoch & handle best (test loss... not "copacetic" but ehh)
         ckpt_path = checkpoints.save_checkpoint(
-            f"checkpoints/{dataset}/{model}-d_model={d_model}-drop2D-schedule",
+            f"checkpoints/{dataset}/{model}-d_model={d_model}",
             state,
             epoch,
             keep=epochs,
@@ -381,13 +381,13 @@ def example_train(
             # Create new "best-{step}.ckpt and remove old one
             shutil.copy(
                 ckpt_path,
-                f"checkpoints/{dataset}/{model}-d_model={d_model}-drop2D-schedule/best_{epoch}",
+                f"checkpoints/{dataset}/{model}-d_model={d_model}/best_{epoch}",
             )
             if os.path.exists(
-                f"checkpoints/{dataset}/{model}-d_model={d_model}-drop2D-schedule/best_{best_epoch}"
+                f"checkpoints/{dataset}/{model}-d_model={d_model}/best_{best_epoch}"
             ):
                 os.remove(
-                    f"checkpoints/{dataset}/{model}-d_model={d_model}-drop2D-schedule/best_{best_epoch}"
+                    f"checkpoints/{dataset}/{model}-d_model={d_model}/best_{best_epoch}"
                 )
 
             best_loss, best_acc, best_epoch = test_loss, test_acc, epoch

--- a/s4/train.py
+++ b/s4/train.py
@@ -33,17 +33,77 @@ def compute_accuracy(logits, label):
 
 
 # As we're using Flax, we also write a utility function to return a default TrainState object.
-# This function initializes model parameters, as well as our optimizer.
+# This function initializes model parameters, as well as our optimizer. Note that for S4 models,
+# we use a custom learning rate for parameters of the S4 kernel (lr = 0.001, no weight decay).
+def map_nested_fn(fn):
+    """Recursively apply `fn to the key-value pairs of a nested dict / pytree."""
+
+    def map_fn(nested_dict):
+        return {
+            k: (map_fn(v) if hasattr(v, "keys") else fn(k, v))
+            for k, v in nested_dict.items()
+        }
+
+    return map_fn
 
 
-def create_train_state(model, rng, in_dim=1, bsz=128, seq_len=784, lr=1e-3):
-    model = model(training=True)
+def create_train_state(
+    model_name,
+    model_cls,
+    rng,
+    in_dim=1,
+    bsz=128,
+    seq_len=784,
+    lr=1e-3,
+    lr_schedule=False,
+    total_steps=-1,
+):
+    model = model_cls(training=True)
     init_rng, dropout_rng = jax.random.split(rng, num=2)
     params = model.init(
         {"params": init_rng, "dropout": dropout_rng},
         np.ones((bsz, seq_len - 1, in_dim)),
-    )["params"]
-    tx = optax.adamw(lr)
+    )[
+        "params"
+    ].unfreeze()  # Note: Added immediate `unfreeze()` to play well w/ Optax. See below!
+
+    # Implement LR Schedule (No change for first 30% of training, then decay w/ cubic polynomial to 0 for last 70%)
+    if lr_schedule:
+        lr = optax.polynomial_schedule(
+            init_value=lr,
+            end_value=0.0,
+            power=3,
+            transition_begin=int(0.3 * total_steps),
+            transition_steps=int(0.7 * total_steps),
+        )
+
+    # S4 uses a Fixed LR = 1e-3 with NO weight decay for the S4 Matrices, higher LR elsewhere
+    if "s4" in model_name:
+        # Note for Debugging... this is all undocumented and so weird. The following links are helpful...
+        #
+        #   > Flax "Recommended" interplay w/ Optax (this bridge needs ironing):
+        #       https://github.com/google/flax/blob/main/docs/flip/1009-optimizer-api.md#multi-optimizer
+        #
+        #   > But... masking doesn't work like the above example suggests!
+        #       Root Explanation: https://github.com/deepmind/optax/issues/159
+        #       Fix: https://github.com/deepmind/optax/discussions/167
+        #
+        #   > Also... Flax FrozenDict doesn't play well with rest of Jax + Optax...
+        #       https://github.com/deepmind/optax/issues/160#issuecomment-896460796
+        #
+        #   > Solution: Use Optax.multi_transform!
+        s4_fn = map_nested_fn(lambda k, _: "s4" if k in ["B", "C"] else "regular")
+        tx = optax.multi_transform(
+            {
+                "s4": optax.adam(learning_rate=1e-3),
+                "regular": optax.adamw(learning_rate=lr, weight_decay=0.01),
+            },
+            s4_fn,
+        )
+
+    else:
+        tx = optax.adamw(learning_rate=lr, weight_decay=0.01)
+
     return train_state.TrainState.create(apply_fn=model.apply, params=params, tx=tx)
 
 
@@ -189,7 +249,12 @@ class SeqModel(nn.Module):
                     nn.LayerNorm(),
                     nn.Dense(self.d_model),
                     nn.Dense(self.d_model),
-                    nn.Dropout(self.dropout, deterministic=not self.training),
+                    # Dropout2D is critical... we want to drop entire channels --> so share mask over 0th (L) dim?
+                    nn.Dropout(
+                        self.dropout,
+                        broadcast_dims=[0],
+                        deterministic=not self.training,
+                    ),
                 )
                 for _ in range(self.n_layers)
             ]
@@ -239,6 +304,7 @@ def example_train(
     epochs=10,
     ssm_n=64,
     lr=1e-3,
+    lr_schedule=False,
 ):
     # Set randomness...
     print("[*] Setting Randomness...")
@@ -272,7 +338,15 @@ def example_train(
         classification=classification,
     )
     state = create_train_state(
-        model_cls, rng, in_dim=in_dim, bsz=bsz, seq_len=seq_len, lr=lr
+        model,
+        model_cls,
+        rng,
+        in_dim=in_dim,
+        bsz=bsz,
+        seq_len=seq_len,
+        lr=lr,
+        lr_schedule=lr_schedule,
+        total_steps=len(trainloader) * epochs,
     )
 
     # Loop over epochs
@@ -296,7 +370,7 @@ def example_train(
 
         # Save a checkpoint each epoch & handle best (test loss... not "copacetic" but ehh)
         ckpt_path = checkpoints.save_checkpoint(
-            f"checkpoints/{dataset}/{model}-d_model={d_model}",
+            f"checkpoints/{dataset}/{model}-d_model={d_model}-drop2D-schedule",
             state,
             epoch,
             keep=epochs,
@@ -307,13 +381,13 @@ def example_train(
             # Create new "best-{step}.ckpt and remove old one
             shutil.copy(
                 ckpt_path,
-                f"checkpoints/{dataset}/{model}-d_model={d_model}/best_{epoch}",
+                f"checkpoints/{dataset}/{model}-d_model={d_model}-drop2D-schedule/best_{epoch}",
             )
             if os.path.exists(
-                f"checkpoints/{dataset}/{model}-d_model={d_model}/best_{best_epoch}"
+                f"checkpoints/{dataset}/{model}-d_model={d_model}-drop2D-schedule/best_{best_epoch}"
             ):
                 os.remove(
-                    f"checkpoints/{dataset}/{model}-d_model={d_model}/best_{best_epoch}"
+                    f"checkpoints/{dataset}/{model}-d_model={d_model}-drop2D-schedule/best_{best_epoch}"
                 )
 
             best_loss, best_acc, best_epoch = test_loss, test_acc, epoch
@@ -342,6 +416,7 @@ if __name__ == "__main__":
 
     # Optimization Parameters
     parser.add_argument("--lr", type=float, default=1e-3)
+    parser.add_argument("--lr_schedule", default=False, action="store_true")
 
     args = parser.parse_args()
 
@@ -353,4 +428,5 @@ if __name__ == "__main__":
         bsz=args.bsz,
         ssm_n=args.ssm_n,
         lr=args.lr,
+        lr_schedule=args.lr_schedule,
     )


### PR DESCRIPTION
As part of quest to replicate CIFAR results (~89% from original repo [as reported here](https://github.com/HazyResearch/state-spaces/blob/feeab742e9c737c8e2b8b0e44d3efff4049f5847/example.py#L20)), implement some of the more nuanced details from the original codebase.

Includes:
- S4-specific optimization (low LR, no weight decay for S4 `B, C` params), regular LR + weight decay for others.
- Dropout2D (important) vs. 1D... not sure if this is totally right, but we want to drop out entire "channels" (timesteps)
- Fix default hyperparameters (learning rate, weight decay)
- LR Schedule (not exactly the same as original, but does matter)

Implementing the above found a few Jax/Flax oddities (especially in the relationship between Flax and Optax), as well as some other details in the original S4 code that seem important:
- In original S4 code, [the step size `dt` for discretization is learned](https://github.com/HazyResearch/state-spaces/blob/feeab742e9c737c8e2b8b0e44d3efff4049f5847/src/models/sequence/ss/kernel.py#L187). This alone shouldn't explain discrepancy in results. 
- By default Flax.Dropout w/ `deterministic = False` does [some weird rescaling stuff that shouldn't matter](https://flax.readthedocs.io/en/latest/_autosummary/flax.linen.Dropout.html#flax.linen.Dropout.deterministic) but haven't tested.
- Generally some [weird update logic I don't fully understand](https://github.com/HazyResearch/state-spaces/blob/feeab742e9c737c8e2b8b0e44d3efff4049f5847/src/models/sequence/ss/standalone/s4.py#L907).
- Parameter initialization is also different in original implementation.

General thoughts: I'm pretty confident that our implementation is educational and technically sound, and not missing anything major (Albert/Karan read through it at a high-level and said we hit the major points). 

But, if we want to replicate the SOTA results in the original repo, there's probably a million little things that we can tweak that will all add up to the results from the other repo... unclear how important they are in telling the story.

(Tentatively) Resolves #16. 