### PR TITLE
Add Weights and Biases Logging

### DIFF
--- a/requirements-cpu.txt
+++ b/requirements-cpu.txt
@@ -16,3 +16,4 @@ tensorflow
 tqdm
 seaborn
 celluloid
+wandb

--- a/requirements-gpu.txt
+++ b/requirements-gpu.txt
@@ -16,3 +16,4 @@ tensorflow
 tqdm
 seaborn
 celluloid
+wandb

--- a/s4/train.py
+++ b/s4/train.py
@@ -11,6 +11,13 @@ from .data import Datasets
 from .s4 import BatchSeqModel, S4LayerInit, SSMInit
 
 
+try:
+    import wandb
+
+    assert hasattr(wandb, "__version__")  # verify package import not local dir
+except (ImportError, AssertionError):
+    wandb = None
+
 # ## Baseline Models
 #
 # We start with definitions of various models we're already familiar with, starting with a feed-forward
@@ -273,11 +280,17 @@ def example_train(
     n_layers=4,
     p_dropout=0.2,
     suffix=None,
+    use_wandb=True,
+    wandb_project="s4",
+    wandb_entity=None,
 ):
     # Set randomness...
     print("[*] Setting Randomness...")
     key = jax.random.PRNGKey(0)
     key, rng, train_rng = jax.random.split(key, num=3)
+
+    if use_wandb:
+        wandb.init(project=wandb_project, entity=wandb_entity)
 
     # Get model class and dataset creation function
     create_dataset_fn = Datasets[dataset]
@@ -366,6 +379,18 @@ def example_train(
             f" {best_acc:.4f} at Epoch {best_epoch + 1}\n"
         )
 
+        if use_wandb:
+            wandb.log(
+                {
+                    "Training Loss": train_loss,
+                    "Test Loss": test_loss,
+                    "Test Accuracy": test_acc,
+                }
+            )
+            wandb.run.summary["Best Test Loss"] = best_loss
+            wandb.run.summary["Best Test Accuracy"] = best_acc
+            wandb.run.summary["Best Epoch"] = best_epoch
+
 
 if __name__ == "__main__":
     import argparse
@@ -393,6 +418,26 @@ if __name__ == "__main__":
     parser.add_argument("--lr", type=float, default=1e-3)
     parser.add_argument("--lr_schedule", default=False, action="store_true")
 
+    # Weights and Biases Parameters
+    parser.add_argument(
+        "--use_wandb",
+        default=True,
+        type=bool,
+        help="Whether to use W&B for metric logging",
+    )
+    parser.add_argument(
+        "--wandb_project",
+        default="s4",
+        type=str,
+        help="Name of the W&B Project",
+    )
+    parser.add_argument(
+        "--wandb_entity",
+        default=None,
+        type=str,
+        help="entity to use for W&B logging",
+    )
+
     args = parser.parse_args()
 
     example_train(
@@ -407,4 +452,7 @@ if __name__ == "__main__":
         n_layers=args.n_layers,
         p_dropout=args.p_dropout,
         suffix=args.suffix,
+        use_wandb=args.use_wandb,
+        wandb_project=args.wandb_project,
+        wandb_entity=args.wandb_entity,
     )


### PR DESCRIPTION
This PR aims to add basic [**Weights and Biases**](https://wandb.ai/site) Metric Logging by appending to the existing training scripts with minimal changes. 

The PR adds 3 extra arguments namely `--use_wandb`, `--wandb_project` and `--wandb_entity` which can be used to specify whether to use wandb, the name of the project to be used (`"s4"` by default) and name of the entity to be used.