### PR TITLE
Add reference to S4D post from main post

### DIFF
--- a/s4/s4.py
+++ b/s4/s4.py
@@ -13,6 +13,8 @@
 
 # *Blog Post and [Library](https://github.com/srush/annotated-s4/) by [Sasha Rush](http://rush-nlp.com/) and [Sidd Karamcheti](https://www.siddkaramcheti.com/)*, v3
 
+# *See also [The Annotated S4D](https://srush.github.io/annotated-s4/s4d), a follow-up but standalone post on simplifications to the S4 model.*
+
 #
 # The [Structured State Space for Sequence
 # Modeling](https://arxiv.org/abs/2111.00396) (S4) architecture is a new approach to very


### PR DESCRIPTION
I occasionally still have to link people independently to the S4D post; I realized there's no reference from the main annotated S4. Can I add this link?